### PR TITLE
Made magic_file_path only apply in windows

### DIFF
--- a/validatedfile/fields.py
+++ b/validatedfile/fields.py
@@ -3,6 +3,7 @@ from django import forms
 from django.template.defaultfilters import filesizeformat
 from django.utils.translation import ugettext as _
 from django.conf import settings
+import os
 
 import magic
 
@@ -20,9 +21,10 @@ class ValidatedFileField(models.FileField):
 
         if self.content_types:
             uploaded_content_type = getattr(file, 'content_type', '')
-
+            
+            # magic_file_path used only for Windows.
             magic_file_path = getattr(settings, "MAGIC_FILE_PATH", None)
-            if magic_file_path:
+            if magic_file_path and os.name == 'nt':
                 mg = magic.Magic(mime=True, magic_file=magic_file_path)
             else:
                 mg = magic.Magic(mime=True)


### PR DESCRIPTION
So that applications that have magic_file_path defined work in both windows and linux. (magic_file_path _must_ not defined in linux)